### PR TITLE
Changed buffer.ReadFrom to keep connection.

### DIFF
--- a/service/sendrecv.go
+++ b/service/sendrecv.go
@@ -62,8 +62,9 @@ func (this *service) receiver() {
 	switch conn := this.conn.(type) {
 	case net.Conn:
 		//glog.Debugf("server/handleConnection: Setting read deadline to %d", time.Second*time.Duration(this.keepAlive))
+		keepAlive := time.Second * time.Duration(this.keepAlive)
 		r := timeoutReader{
-			d:    time.Second * time.Duration(this.keepAlive),
+			d:    keepAlive + (keepAlive / 2),
 			conn: conn,
 		}
 


### PR DESCRIPTION
I'm using Go 1.5 (darwin/amd64) with current external packages.

Issue #17 is occurred in my environment.

for example, I ran:

    $ cd example/surgemq
    $ go run surgemq.go

Then I connect to surgemq server with other MQTT client.
buffer.ReadFrom loops r.Read.
Although r.SetReadDeadline is called once at service.receiver().