### PR TITLE
changed glog.Errorf format to fix wrong type verb

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -228,7 +228,7 @@ func (this *service) stop() {
 		} else {
 			for _, t := range topics {
 				if err := this.topicsMgr.Unsubscribe([]byte(t), &this.onpub); err != nil {
-					glog.Errorf("(%d/%s): Error unsubscribing topic %q: %v", this.cid(), t, err)
+					glog.Errorf("(%s): Error unsubscribing topic %q: %v", this.cid(), t, err)
 				}
 			}
 		}


### PR DESCRIPTION
I fixed a `go vet` error.
Verb must use "(%s)" for service.cid().

```
$ cd service
$ go vet
service.go:231: arg this.cid() for printf verb %d of wrong type: string
exit status 1
$ go version
go version go1.5 darwin/amd64
```