### PR TITLE
fixed resource cleanups #26

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -242,12 +242,12 @@ func (this *service) stop() {
 
 	// Remove the client topics manager
 	if this.client {
-		topics.Unregister(this.cid())
+		topics.Unregister(this.sess.ID())
 	}
 
 	// Remove the session from session store if it's suppose to be clean session
 	if this.sess.Cmsg.CleanSession() && this.sessMgr != nil {
-		this.sessMgr.Del(this.cid())
+		this.sessMgr.Del(this.sess.ID())
 	}
 
 	this.conn = nil


### PR DESCRIPTION
I've found two resource leaks.

* wrong key for unregister client topic
* wrong key for cleanup a session

I ran SurgeMQ with this patch.
These leaks are solved.