### PR TITLE
FIX paho test

### DIFF
--- a/service/paho_test.go
+++ b/service/paho_test.go
@@ -24,11 +24,11 @@ import (
 	"testing"
 	"time"
 
-	MQTT "git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git"
+	MQTT "github.com/eclipse/paho.mqtt.golang"
 	"github.com/stretchr/testify/require"
 )
 
-var f MQTT.MessageHandler = func(client *MQTT.Client, msg MQTT.Message) {
+var f MQTT.MessageHandler = func(client MQTT.Client, msg MQTT.Message) {
 	fmt.Printf("TOPIC: %s\n", msg.Topic())
 	fmt.Printf("MSG: %s\n", msg.Payload())
 }


### PR DESCRIPTION
`eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git ` is not accessible anymore.